### PR TITLE
Fix task input key handling

### DIFF
--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -55,3 +55,29 @@ func TestTabCyclesModes(t *testing.T) {
 		t.Fatalf("expected tasks, got %s", m3.mode)
 	}
 }
+
+func TestAddingTaskInput(t *testing.T) {
+	dbPath := "test.db"
+	if err := model.InitDB(dbPath); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+	defer func() {
+		model.CloseDB()
+		os.Remove(dbPath)
+	}()
+
+	m := initialModel()
+	m.mode = "adding_task"
+
+	letters := []rune{'d', 'n', 'e', 'q', 'x'}
+	for _, r := range letters {
+		km := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		next, _ := m.Update(km)
+		m = next.(modelState)
+	}
+
+	expected := "dneqx"
+	if m.newTaskName != expected {
+		t.Fatalf("expected %s, got %s", expected, m.newTaskName)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent global keybindings from eating characters while adding
- simplify character input to accept any runes
- test default key handling for adding tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686b7dbd9b6c83289424f3ec5bd0ab4c