### PR TITLE
Enable global day navigation and quit via ctrl+c

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -51,7 +51,7 @@ var (
 // keybindings for application commands
 var keys = struct {
 	Left, Right, Up, Down, Tab, Enter, Escape, Backspace, Space,
-	N, E, A, D, Q key.Binding
+	N, E, A, D, Quit key.Binding
 }{
 	Left:      key.NewBinding(key.WithKeys("left"), key.WithHelp("←", "prev day")),
 	Right:     key.NewBinding(key.WithKeys("right"), key.WithHelp("→", "next day")),
@@ -66,7 +66,7 @@ var keys = struct {
 	E:         key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit note")),
 	A:         key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "add")),
 	D:         key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
-	Q:         key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+	Quit:      key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
 }
 
 type modelState struct {
@@ -197,11 +197,11 @@ func (m modelState) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// general keybindings via bubbletea key.Matches
 		switch {
 		case key.Matches(msg, keys.Left):
-			if m.mode == "calendar" && m.selected > 0 {
+			if m.selected > 0 {
 				m.selected--
 			}
 		case key.Matches(msg, keys.Right):
-			if m.mode == "calendar" && m.selected < 6 {
+			if m.selected < len(m.dates)-1 {
 				m.selected++
 			}
 		case key.Matches(msg, keys.Up):
@@ -289,7 +289,7 @@ func (m modelState) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, keys.Backspace):
 			// ignore in non-input modes
-		case key.Matches(msg, keys.Q):
+		case key.Matches(msg, keys.Quit):
 			return m, tea.Quit
 		default:
 			// ignore other keys
@@ -472,13 +472,13 @@ func (m modelState) View() string {
 
 	var controls string
 	if m.mode == "calendar" {
-		controls = "Calendar: ←/→ navigate | Tab: switch to habits | q: quit"
+		controls = "Calendar: ←/→ navigate days | Tab: switch to habits | ctrl+c: quit"
 	} else if m.mode == "habits" {
-		controls = "Habits: ↑/↓ navigate | Space: toggle | n: notes | e: edit | d: delete | a: add | Tab: tasks | q: quit"
+		controls = "Habits: ←/→ change day | ↑/↓ navigate | Space: toggle | n: notes | e: edit | d: delete | a: add | Tab: tasks | ctrl+c: quit"
 	} else if m.mode == "tasks" {
-		controls = "Tasks: ↑/↓ navigate | Space: toggle | d: delete | a: add | Tab: stats | q: quit"
+		controls = "Tasks: ←/→ change day | ↑/↓ navigate | Space: toggle | d: delete | a: add | Tab: stats | ctrl+c: quit"
 	} else if m.mode == "stats" {
-		controls = "Statistics: View habit streaks and progress | Tab: calendar | q: quit"
+		controls = "Statistics: ←/→ change day | View habit streaks and progress | Tab: calendar | ctrl+c: quit"
 	} else if m.mode == "choosing_habit_type" {
 		controls = "↑/↓ select type | Enter: next | Esc: cancel"
 	} else if m.mode == "adding" {

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -81,3 +81,32 @@ func TestAddingTaskInput(t *testing.T) {
 		t.Fatalf("expected %s, got %s", expected, m.newTaskName)
 	}
 }
+
+func TestArrowKeysMoveDaysInAllModes(t *testing.T) {
+	dbPath := "test.db"
+	if err := model.InitDB(dbPath); err != nil {
+		t.Fatalf("failed to init db: %v", err)
+	}
+	defer func() {
+		model.CloseDB()
+		os.Remove(dbPath)
+	}()
+
+	m := initialModel()
+	m.mode = "habits"
+	m.selected = 3
+
+	left := tea.KeyMsg{Type: tea.KeyLeft}
+	next, _ := m.Update(left)
+	m2 := next.(modelState)
+	if m2.selected != 2 {
+		t.Fatalf("expected selected 2, got %d", m2.selected)
+	}
+
+	right := tea.KeyMsg{Type: tea.KeyRight}
+	next2, _ := m2.Update(right)
+	m3 := next2.(modelState)
+	if m3.selected != 3 {
+		t.Fatalf("expected selected 3, got %d", m3.selected)
+	}
+}


### PR DESCRIPTION
## Summary
- change keybindings to use `ctrl+c` instead of `q` for quitting
- allow left/right arrows to move the selected day in any section
- update help text for new quit key and navigation
- test that days can be changed while in habit mode

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686b88aab3f0832898101a2a28751d7e